### PR TITLE
Updated node-px2rem to version 1.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/ggkovacs/gulp-px2rem",
   "dependencies": {
     "gulp-util": "3.0.6",
-    "node-px2rem": "1.0.4",
+    "node-px2rem": "1.0.5",
     "through2": "2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
:rocket:

node-px2rem just published version 1.0.5, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 4 commits (ahead by 4, behind by 0).

- [070047f](https://github.com/ggkovacs/node-px2rem/commit/070047f5639962dda9c36a35820aad2b15597191): bump version
- [085f3c0](https://github.com/ggkovacs/node-px2rem/commit/085f3c0af5c2e9f086f0b65cdada7cf17b1c0c92): Merge pull request #2 from ggkovacs/greenkeeper-pin
- [084c063](https://github.com/ggkovacs/node-px2rem/commit/084c0636d82957d42129bd5640894121e9e8ccfe): chore(package): pin dependencies
- [035e138](https://github.com/ggkovacs/node-px2rem/commit/035e1381c6621cd2fc7c7c1f93bcf8589d53ad61): update jshint, jscs

See the [full diff](https://github.com/ggkovacs/node-px2rem/compare/50c20d724b688039983ec3d9496c1533f261868e...070047f5639962dda9c36a35820aad2b15597191).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>