### PR TITLE
Replace deprecated gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
-var util = require('gulp-util');
-var PluginError = util.PluginError;
+var PluginError = require('plugin-error');
 var through = require('through2');
 var px2rem = require('node-px2rem');
 

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   },
   "homepage": "https://github.com/ggkovacs/gulp-px2rem",
   "dependencies": {
-    "gulp-util": "^3.0.8",
     "node-px2rem": "^1.1.6",
+    "plugin-error": "^1.0.1",
     "through2": "^2.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
[`gulp-util`](https://www.npmjs.com/package/gulp-util) has been deprecated recently. Continuing to use this dependency may prevent the use of your library with the recently released version 4 of Gulp.

See:
- https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
- https://github.com/gulpjs/gulp-util/issues/143